### PR TITLE
m2-filesystem: Add missing Library prefix

### DIFF
--- a/recipe/msys2-pkgs.py
+++ b/recipe/msys2-pkgs.py
@@ -328,7 +328,7 @@ for pkg, (depends, spdx, desc, url, src_url) in seen.items():
       prefix_detection:
         force_file_type:
           text:
-            - etc/fstab"""
+            - Library/etc/fstab"""
 
     skip = "false"
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,7 +3,7 @@ recipe:
   version: "20250515"
 
 build:
-  number: 7
+  number: 8
   noarch: generic
   dynamic_linking:
     overlinking_behavior: ignore
@@ -2332,7 +2332,7 @@ outputs:
       prefix_detection:
         force_file_type:
           text:
-            - etc/fstab
+            - Library/etc/fstab
       skip: false
     requirements:
       host:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Missing the `Library` prefix, sorry... Fixed #20